### PR TITLE
Added NamedLock.guard `waiting` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,9 @@
 - TODO: Add explicit NamedLocks.guardAsync() method for explicit async executions
 - TODO: In code dartdoc comments for pub.dev API documentation
 
+## 1.0.0-beta.5
+- Implemented `String? waiting` property on NamedLocks.guard() method to allow for a custom message to be displayed when waiting for the lock to locked by the current process ahead of execution
+- TODO: Leveraging NamedLocks directly i.e. outside the NamedLock.guard() function
+- TODO: Add explicit NamedLocks.guardAsync() method for explicit async executions
+- TODO: In code dartdoc comments for pub.dev API documentation
+

--- a/lib/src/named_lock.dart
+++ b/lib/src/named_lock.dart
@@ -162,7 +162,7 @@ class NamedLock {
   // Guard will create a new lock fo you with the given lock name
   // Guard and execute some code with the lock held and released it the internal execution completes
   static ExecutionCall<R, E> guard<R, E extends Exception>(
-      {required String name, required ExecutionCall<R, E> execution, Duration timeout = const Duration(seconds: 5), bool verbose = false}) {
+      {required String name, required ExecutionCall<R, E> execution, Duration timeout = const Duration(seconds: 5), bool verbose = false, String? waiting}) {
     execution.guarding = true;
 
     LockType lock = Platform.isWindows ? WindowsLock.instantiate(name: name) : UnixLock.instantiate(name: name);
@@ -215,6 +215,13 @@ class NamedLock {
           print(
               'NamedLock is not locked: $locked within the NamedLock.guard execution loop and about to sleep for ${_sleep.inMilliseconds} milliseconds due to the lock not being acquired.');
         sleep(_sleep);
+
+        // On first attempt if we are not locked we can print the waiting message
+        if(_attempt == 1 && waiting is String) {
+          print(waiting);
+          waiting = null;
+        }
+
         _sleep = Duration(milliseconds: (_sleep.inMilliseconds + _attempt * 10).clamp(5, 500));
         if (verbose)
           print(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: runtime_named_locks
 homepage: https://pieces.app
 repository: https://github.com/open-runtime/named_locks
-version: 1.0.0-beta.4
+version: 1.0.0-beta.5
 description: A library for creating and managing named locks which leverages Dart FFI and Native Named Semaphores across across macOS, Linux, and Windows.
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
Implemented `String? waiting` property on NamedLocks.guard() method to allow for a custom message to be displayed when waiting for the lock to locked by the current process ahead of execution