### PR TITLE
chore: remove runtime_ci_tooling dev_dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,10 +22,8 @@ dependencies:
     version: ^1.0.0-beta.7
 
 dev_dependencies:
-  runtime_ci_tooling:
-    git:
-      url: git@github.com:open-runtime/runtime_ci_tooling.git
-      tag_pattern: v{{version}}
-    version: ^0.23.0
+  # runtime_ci_tooling — use global activation (do not add as a dev_dependency). Example:
+  #   dart pub global activate --source git https://github.com/open-runtime/runtime_ci_tooling.git --git-ref vX.Y.Z
+  #   dart pub global run runtime_ci_tooling:manage_cicd --help
   test: ^1.25.5
   safe_int_id: ^1.1.1


### PR DESCRIPTION
runtime_ci_tooling is globally activated in CI — not a dev_dependency. Removes workspace resolution conflict.

Made with [Cursor](https://cursor.com)